### PR TITLE
ensure test more create deleted has correct fields

### DIFF
--- a/data-warehouse/Bink/tests/generic/test_more_created_than_deleted.sql
+++ b/data-warehouse/Bink/tests/generic/test_more_created_than_deleted.sql
@@ -29,6 +29,7 @@ Last modified date: 2022/10/26
             ,RANK() OVER ( PARTITION BY {{group_col}} ORDER BY {{datetime_col}} ASC) AS r
         FROM {{model}}
         WHERE {{group_col}} IS NOT null
+        AND {{column_name}} IN ({{ "'" + created_val + "'"}}, {{ "'" + deleted_val + "'"}})
         AND {{datetime_col}} > {{"'" + filter_date + "'"}}
     )
 


### PR DESCRIPTION
Ensure test for more created than deleted only considers the values created and deleted that are entered into the generic test